### PR TITLE
(RHEL-36636) ci: Allow to pass parameters together with rhel-only note 

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -4,8 +4,8 @@ policy:
       - github: systemd/systemd
     exception:
       note:
-        - rhel-only
-        - RHEL-only
+        - 'rhel-only: (feature|bugfix|doc|workaround|ci|test|other)'
+        - 'RHEL-only: (feature|bugfix|doc|workaround|ci|test|other)'
   tracker:
     - keyword:
         - 'Resolves: '


### PR DESCRIPTION
Supported parameters:

* feature - for feature related commits (cross-version)
* bugfix - for bugfix related commits (cross-version)
* doc - for documentation related commits (usually version specific)
* workaround - for workaround related commits (usually version-specific)
* ci - for CI related commits (version specific)
* test - for test related commits (version specific)
* other - for commits that do not fit into any of the above categories or use just `rhel-only`

rhel-only: ci

Related: RHEL-36636

<!-- issue-commentator = {"comment-id":"2182849290"} -->