### PR TITLE
(RHEL-46576) presets: remove resolved

### DIFF
--- a/presets/90-systemd.preset
+++ b/presets/90-systemd.preset
@@ -27,7 +27,6 @@ enable systemd-networkd.service
 enable systemd-networkd-wait-online.service
 enable systemd-nsresourced.socket
 enable systemd-pstore.service
-enable systemd-resolved.service
 enable systemd-sysext.service
 enable systemd-timesyncd.service
 enable systemd-userdbd.socket


### PR DESCRIPTION
We noticed that some people are installing systemd* and then have daemons they don't need running. So let's remove resolved from presets so its usage is a bit more deliberate

RHEL-only: policy

Resolves: RHEL-46576

<!-- issue-commentator = {"comment-id":"2213744346"} -->