### PR TITLE
(RHEL-46277) taint: remove unmerged-bin

### DIFF
--- a/catalog/systemd.catalog.in
+++ b/catalog/systemd.catalog.in
@@ -560,7 +560,6 @@ Support: %SUPPORT_URL%
 The following "tags" are possible:
 - "unmerged-usr" - /bin, /sbin, /lib* are not symlinks to their counterparts
   under /usr/
-- "unmerged-bin" - /usr/sbin is not a symlink to /usr/bin/
 - "var-run-bad" — /var/run is not a symlink to /run/
 - "cgroupsv1" - the system is using the deprecated cgroup v1 hierarchy
 - "local-hwclock" - the local hardware clock (RTC) is configured to be in

--- a/catalog/systemd.pl.catalog.in
+++ b/catalog/systemd.pl.catalog.in
@@ -566,7 +566,6 @@ Support: %SUPPORT_URL%
 Możliwe są następujące „etykiety”:
 • „unmerged-usr” — /bin, /sbin, /lib* nie są dowiązaniami symbolicznymi
   do swoich odpowiedników pod /usr/,
-• „unmerged-bin” — /usr/sbin nie jest dowiązaniem symbolicznym do /usr/bin/,
 • „var-run-bad” — /var/run nie jest dowiązaniem symbolicznym do /run/,
 • „cgroupsv1” — system używa przestarzałej hierarchii cgroup v1,
 • „local-hwclock” — lokalny zegar sprzętowy (RTC) jest skonfigurowany

--- a/man/org.freedesktop.systemd1.xml
+++ b/man/org.freedesktop.systemd1.xml
@@ -1667,15 +1667,6 @@ node /org/freedesktop/systemd1 {
         </varlistentry>
 
         <varlistentry>
-          <term><literal>unmerged-bin</literal></term>
-
-          <listitem><para><filename>/usr/sbin</filename> is not a symlink to <filename>/usr/bin/</filename>.
-          </para>
-
-          <xi:include href="version-info.xml" xpointer="v256"/></listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term><literal>var-run-bad</literal></term>
 
           <listitem><para><filename>/run/</filename> does not exist or <filename>/var/run</filename> is not a

--- a/src/core/taint.c
+++ b/src/core/taint.c
@@ -32,7 +32,7 @@ static int short_uid_gid_range(UIDRangeUsernsMode mode) {
 }
 
 char* taint_string(void) {
-        const char *stage[12] = {};
+        const char *stage[11] = {};
         size_t n = 0;
 
         /* Returns a "taint string", e.g. "local-hwclock:var-run-bad". Only things that are detected at
@@ -43,11 +43,6 @@ char* taint_string(void) {
 
         if (readlink_malloc("/bin", &bin) < 0 || !PATH_IN_SET(bin, "usr/bin", "/usr/bin"))
                 stage[n++] = "unmerged-usr";
-
-        /* Note that the check is different from default_PATH(), as we want to taint on uncanonical symlinks
-         * too. */
-        if (readlink_malloc("/usr/sbin", &usr_sbin) < 0 || !PATH_IN_SET(usr_sbin, "bin", "/usr/bin"))
-                stage[n++] = "unmerged-bin";
 
         if (readlink_malloc("/var/run", &var_run) < 0 || !PATH_IN_SET(var_run, "../run", "/run"))
                 stage[n++] = "var-run-bad";


### PR DESCRIPTION
In rhel10 we will have separate bin and sbin

RHEL-only: policy

Resolves: RHEL-46277

<!-- issue-commentator = {"comment-id":"2213990454"} -->