### PR TITLE
(RHEL-40924) ci: run mkosi test only for Fedora and CentOS Stream

### DIFF
--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - main
-      - v[0-9]+-stable
+      - rhel-10.*
     paths:
       - '**'
       - '!README*'
@@ -26,7 +26,7 @@ on:
   pull_request:
     branches:
       - main
-      - v[0-9]+-stable
+      - rhel-10.*
     paths:
       - '**'
       - '!README*'
@@ -54,21 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: arch
-            release: rolling
-            sanitizers: ""
-            llvm: 0
-            cflags: "-O2 -D_FORTIFY_SOURCE=3"
-          - distro: debian
-            release: testing
-            sanitizers: ""
-            llvm: 0
-            cflags: "-Og"
-          - distro: ubuntu
-            release: noble
-            sanitizers: ""
-            llvm: 0
-            cflags: "-Og"
           - distro: fedora
             release: "40"
             sanitizers: ""
@@ -78,11 +63,6 @@ jobs:
             release: rawhide
             sanitizers: address,undefined
             llvm: 1
-            cflags: "-Og"
-          - distro: opensuse
-            release: tumbleweed
-            sanitizers: ""
-            llvm: 0
             cflags: "-Og"
           - distro: centos
             release: "9"

--- a/src/core/taint.c
+++ b/src/core/taint.c
@@ -39,7 +39,7 @@ char* taint_string(void) {
          * runtime should be tagged here. For stuff that is known during compilation, emit a warning in the
          * configuration phase. */
 
-        _cleanup_free_ char *bin = NULL, *usr_sbin = NULL, *var_run = NULL;
+        _cleanup_free_ char *bin = NULL, *var_run = NULL;
 
         if (readlink_malloc("/bin", &bin) < 0 || !PATH_IN_SET(bin, "usr/bin", "/usr/bin"))
                 stage[n++] = "unmerged-usr";


### PR DESCRIPTION
rhel-only: ci

Related: RHEL-40924

<!-- issue-commentator = {"comment-id":"2230245054"} -->