### PR TITLE
(RHEL-40924) packit: drop the dependency on python3-zstd

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -39,9 +39,6 @@ actions:
     - 'sed -i "/^CONFIGURE_OPTS=(/a--werror" .packit_rpm/systemd.spec'
     # Ignore unpackaged standalone binaries
     - "sed -i 's/assert False,.*/pass/' .packit_rpm/split-files.py"
-    # Temporarily add libarchive-devel build dep and libarchive runtime dep
-    # until the change propagates to Rawhide's specfile
-    - "sed -ri '0,/^BuildRequires: .+$/s//&\\nBuildRequires: libarchive-devel\\nRequires: libarchive/' .packit_rpm/systemd.spec"
 
 # Available targets can be listed via `copr-cli list-chroots`
 jobs:

--- a/.packit.yml
+++ b/.packit.yml
@@ -39,6 +39,9 @@ actions:
     - 'sed -i "/^CONFIGURE_OPTS=(/a--werror" .packit_rpm/systemd.spec'
     # Ignore unpackaged standalone binaries
     - "sed -i 's/assert False,.*/pass/' .packit_rpm/split-files.py"
+    # Drop the python3dist(zstd) dependency, as it's only in the RHEL buildroot
+    # repo
+    - "sed -i '/python3dist(zstd)/d' .packit_rpm/systemd.spec"
 
 # Available targets can be listed via `copr-cli list-chroots`
 jobs:


### PR DESCRIPTION
Since it's only in the RHEL buildroot repo.

rhel-only: ci

Related: RHEL-40924

<!-- issue-commentator = {"comment-id":"2233009773"} -->