### PR TITLE
(RHEL-46778) coredump: by default process and store core files up to 1GiB

### DIFF
--- a/src/coredump/coredump.conf
+++ b/src/coredump/coredump.conf
@@ -19,9 +19,8 @@
 [Coredump]
 #Storage=external
 #Compress=yes
-# On 32-bit, the default is 1G instead of 32G.
-#ProcessSizeMax=32G
-#ExternalSizeMax=32G
+ProcessSizeMax=1G
+ExternalSizeMax=1G
 #JournalSizeMax=767M
 #MaxUse=
 #KeepFree=


### PR DESCRIPTION
This brings policy inline with RHEL-9.

rhel-only: policy

Related: RHEL-46778

<!-- issue-commentator = {"comment-id":"2233454701"} -->