### PR TITLE
(RHEL-51171) sd-event: do not assert on invalid signal

### DIFF
--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -3866,7 +3866,8 @@ static int process_signal(sd_event *e, struct signal_data *d, uint32_t events, i
                 if (_unlikely_(n != sizeof(si)))
                         return -EIO;
 
-                assert(SIGNAL_VALID(si.ssi_signo));
+                if (_unlikely_(!SIGNAL_VALID(si.ssi_signo)))
+                        return -EINVAL;
 
                 if (e->signal_sources)
                         s = e->signal_sources[si.ssi_signo];


### PR DESCRIPTION
The signalfd_siginfo struct is received from outside via a FD, hence assert() is not appropriate way to check it. Just do a normal runtime check.

(cherry picked from commit 7a64c5f23efbb51fe4f1229c1a8aed6dd858a0a9)

Resolves: RHEL-51171

<!-- issue-commentator = {"comment-id":"2258541960"} -->