### PR TITLE
(RHEL-44416) udev-builtin-net_id: use firmware_node/sun for ID_NET_NAME_SLOT

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -528,7 +528,7 @@
         <varlistentry>
           <term><constant>rhel-10.0</constant></term>
 
-          <listitem><para>PCI slot number is now read from <constant>firmware_node/sun</constant> sysfs file</para>
+          <listitem><para>PCI slot number is now read from <constant>firmware_node/sun</constant> sysfs file.</para>
 
           <xi:include href="version-info.xml" xpointer="rhel-10.0"/>
           </listitem>
@@ -604,7 +604,7 @@
           children of the same PCI bridge, e.g. there are multiple PCI bridges in the same slot.
           </para>
 
-          <para>PCI slot number is now read from <constant>firmware_node/sun</constant> sysfs file</para>
+          <para>PCI slot number is now read from <constant>firmware_node/sun</constant> sysfs file.</para>
 
           <xi:include href="version-info.xml" xpointer="rhel-9.5"/>
           </listitem>

--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -528,7 +528,7 @@
         <varlistentry>
           <term><constant>rhel-10.0</constant></term>
 
-          <listitem><para>Same as naming scheme <constant>v255</constant>.</para>
+          <listitem><para>PCI slot number is now read from <constant>firmware_node/sun</constant> sysfs file</para>
 
           <xi:include href="version-info.xml" xpointer="rhel-10.0"/>
           </listitem>
@@ -603,6 +603,8 @@
           to distinguish between devices. However, name conflict can occur if these devices are not
           children of the same PCI bridge, e.g. there are multiple PCI bridges in the same slot.
           </para>
+
+          <para>PCI slot number is now read from <constant>firmware_node/sun</constant> sysfs file</para>
 
           <xi:include href="version-info.xml" xpointer="rhel-9.5"/>
           </listitem>
@@ -798,7 +800,7 @@ ID_NET_NAME_ONBOARD_LABEL=Ethernet Port 1
     </example>
 
     <example>
-      <title>PCI Ethernet card in hotplug slot with firmware index number</title>
+      <title>PCI Ethernet card in slot with firmware index number</title>
 
       <programlisting># /sys/devices/pci0000:00/0000:00:1c.3/0000:05:00.0/net/ens1
 ID_NET_NAME_MAC=enx000000000466

--- a/src/shared/netif-naming-scheme.h
+++ b/src/shared/netif-naming-scheme.h
@@ -43,6 +43,7 @@ typedef enum NamingSchemeFlags {
         NAMING_DEVICETREE_ALIASES        = 1 << 15, /* Generate names from devicetree aliases */
         NAMING_USB_HOST                  = 1 << 16, /* Generate names for usb host */
         NAMING_SR_IOV_R                  = 1 << 17, /* Use "r" suffix for SR-IOV VF representors */
+        NAMING_FIRMWARE_NODE_SUN         = 1 << 18, /* Use firmware_node/sun to get PCI slot number */
 
         /* And now the masks that combine the features above */
         NAMING_V238 = 0,
@@ -80,9 +81,9 @@ typedef enum NamingSchemeFlags {
         NAMING_RHEL_9_2 = NAMING_RHEL_9_0,
         NAMING_RHEL_9_3 = NAMING_RHEL_9_0 | NAMING_SR_IOV_R,
         NAMING_RHEL_9_4 = NAMING_RHEL_9_3,
-        NAMING_RHEL_9_5 = NAMING_RHEL_9_4 & ~NAMING_BRIDGE_MULTIFUNCTION_SLOT,
+        NAMING_RHEL_9_5 = (NAMING_RHEL_9_4 & ~NAMING_BRIDGE_MULTIFUNCTION_SLOT) | NAMING_FIRMWARE_NODE_SUN,
 
-        NAMING_RHEL_10_0 = NAMING_V255,
+        NAMING_RHEL_10_0 = NAMING_V255 | NAMING_FIRMWARE_NODE_SUN,
 
         EXTRA_NET_NAMING_SCHEMES
 


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"2277368520"} -->