### PR TITLE
(RHEL-36636) Revert "packit: drop the dependency on python3-zstd"

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -39,9 +39,6 @@ actions:
     - 'sed -i "/^CONFIGURE_OPTS=(/a--werror" .packit_rpm/systemd.spec'
     # Ignore unpackaged standalone binaries
     - "sed -i 's/assert False,.*/pass/' .packit_rpm/split-files.py"
-    # Drop the python3dist(zstd) dependency, as it's only in the RHEL buildroot
-    # repo
-    - "sed -i '/python3dist(zstd)/d' .packit_rpm/systemd.spec"
 
 # Available targets can be listed via `copr-cli list-chroots`
 jobs:


### PR DESCRIPTION
`python3dist(zstd)` is now available in AppStream

This reverts commit 43bf3e1a42e2c1a6ecd0ca6fd72c9bc6fe904703.

rhel-only: ci

Related: RHEL-36636

<!-- issue-commentator = {"comment-id":"2288393295"} -->