### PR TITLE
(RHEL-55132) systemctl: do not try to acquire triggering units for template units

### DIFF
--- a/src/systemctl/systemctl-util.c
+++ b/src/systemctl/systemctl-util.c
@@ -327,14 +327,15 @@ int get_active_triggering_units(sd_bus *bus, const char *unit, bool ignore_maske
         if (r < 0)
                 return r;
 
+        if (unit_name_is_valid(name, UNIT_NAME_TEMPLATE))
+                goto skip;
+
         if (ignore_masked) {
                 r = unit_is_masked(bus, name);
                 if (r < 0)
                         return r;
-                if (r > 0) {
-                        *ret = NULL;
-                        return 0;
-                }
+                if (r > 0)
+                        goto skip;
         }
 
         dbus_path = unit_dbus_path_from_name(name);
@@ -369,6 +370,10 @@ int get_active_triggering_units(sd_bus *bus, const char *unit, bool ignore_maske
         }
 
         *ret = TAKE_PTR(active);
+        return 0;
+
+skip:
+        *ret = NULL;
         return 0;
 }
 


### PR DESCRIPTION
(cherry picked from commit 09d6038d833468ba7c24c658597387ef699ca4fd)

Resolves: RHEL-55132

<!-- issue-commentator = {"comment-id":"2298837200"} -->