### PR TITLE
(RHEL-52634) Revert "cgroup-util: Don't try to open pidfd for kernel threads"

### DIFF
--- a/src/basic/cgroup-util.c
+++ b/src/basic/cgroup-util.c
@@ -149,9 +149,7 @@ int cg_read_pidref(FILE *f, PidRef *ret, CGroupFlags flags) {
                 if (pid == 0)
                         return -EREMOTE;
 
-                /* We might read kernel thread pids from cgroup.procs for which we cannot create a pidfd so
-                 * catch those and don't try to create a pidfd for them. */
-                if (FLAGS_SET(flags, CGROUP_NO_PIDFD) || pid_is_kernel_thread(pid) > 0) {
+                if (FLAGS_SET(flags, CGROUP_NO_PIDFD)) {
                         *ret = PIDREF_MAKE_FROM_PID(pid);
                         return 1;
                 }


### PR DESCRIPTION
The kernel patch was reverted so let's try again to open pidfds for kernel threads.

This reverts commit ead48ec35c863650944352a3455f26ce3b393058.

(cherry picked from commit 1ce69e06615e69692a6d02d447acfd77f5d44631)

follow-up to:
- #34 

<!-- issue-commentator = {"comment-id":"2314969951"} -->