### PR TITLE
(RHEL-52634) ukify: Skip test on architectures without UEFI

### DIFF
--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -35,6 +35,13 @@ except ImportError as e:
 sys.path.append(os.path.dirname(__file__) + '/..')
 import ukify
 
+# Skip if we're running on an architecture that does not use UEFI.
+try:
+    ukify.guess_efi_arch()
+except ValueError as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(77)
+
 build_root = os.getenv('PROJECT_BUILD_ROOT')
 try:
     slow_tests = bool(int(os.getenv('SYSTEMD_SLOW_TESTS', '1')))


### PR DESCRIPTION
(cherry picked from commit 5121f7c45b37afca53c89f42123b1dd6a04fa80f)

Related: RHEL-52634

<!-- issue-commentator = {"comment-id":"2320600259"} -->