### PR TITLE
(RHEL-57603) ci: rename beta branch to match dist-git name

### DIFF
--- a/.github/tracker-validator.yml
+++ b/.github/tracker-validator.yml
@@ -6,7 +6,7 @@ labels:
 products:
   - Red Hat Enterprise Linux 10
   - CentOS Stream 10
-  - rhel-10.0.beta 
+  - rhel-10.0-beta
   - rhel-10.0
   - rhel-10.0.z
   - rhel-10.1


### PR DESCRIPTION
rhel-only: ci

Related: RHEL-57603

<!-- issue-commentator = {"comment-id":"2331195678"} -->