### PR TITLE
(RHEL-59871) udev: Handle PTP device symlink properly on udev action 'change'

### DIFF
--- a/rules.d/50-udev-default.rules.in
+++ b/rules.d/50-udev-default.rules.in
@@ -30,6 +30,9 @@ SUBSYSTEM=="pci|usb|platform", IMPORT{builtin}="path_id"
 
 SUBSYSTEM=="net", IMPORT{builtin}="net_driver"
 
+SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK+="ptp_kvm"
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK+="ptp_hyperv"
+
 ACTION!="add", GOTO="default_end"
 
 SUBSYSTEM=="tty", KERNEL=="ptmx", GROUP="tty", MODE="0666"
@@ -115,8 +118,5 @@ KERNEL=="vhost-vsock", GROUP="kvm", MODE="{{DEV_KVM_MODE}}", OPTIONS+="static_no
 KERNEL=="vhost-net", GROUP="kvm", MODE="{{DEV_KVM_MODE}}", OPTIONS+="static_node=vhost-net"
 
 KERNEL=="udmabuf", GROUP="kvm"
-
-SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK+="ptp_kvm"
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK+="ptp_hyperv"
 
 LABEL="default_end"


### PR DESCRIPTION
PTP device symlink creation rules are currently executed only when the udev action is 'add'. If a user reloads the rules and runs the udevadm trigger command to reapply changes, the symlink may be deleted, which can prevent the chronyd service from restarting properly.

Signed-off-by: Chengen Du <chengen.du@canonical.com>
(cherry picked from commit 6bd12be3fa7761f190e17efdbdbff4440da7528b)

Resolves: RHEL-59871

<!-- issue-commentator = {"comment-id":"2370649108"} -->