### PR TITLE
(RHEL-85854) test_ukify: Skip on riscv64

### DIFF
--- a/src/ukify/test/test_ukify.py
+++ b/src/ukify/test/test_ukify.py
@@ -52,6 +52,11 @@ except ValueError as e:
     print(str(e), file=sys.stderr)
     sys.exit(77)
 
+# Skip this test on riscv64 for now. It needs binutils 2.42 to work
+# on the architecture, but we only have 2.41 in RHEL 10
+if ukify.guess_efi_arch() == 'riscv64':
+    sys.exit(77)
+
 build_root = os.getenv('PROJECT_BUILD_ROOT')
 try:
     slow_tests = bool(int(os.getenv('SYSTEMD_SLOW_TESTS', '1')))


### PR DESCRIPTION
The test needs binutils 2.42 to work on the architecture, but we only have 2.41 in RHEL 10.

Signed-off-by: Andrea Bolognani <abologna@redhat.com>

rhel-only: test

Resolves: RHEL-85854

/cc @andreabolognani

<!-- issue-commentator = {"comment-id":"2793004270"} -->