### PR TITLE
man: mention that rhel-9.0 net naming scheme is the same as v251

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -568,7 +568,8 @@
         <varlistentry>
           <term><constant>rhel-9.0</constant></term>
 
-          <listitem><para>Since version <constant>v247</constant> we no longer set
+          <listitem><para>Same as naming scheme <constant>v251</constant>.</para>
+          <para>Since version <constant>v247</constant> we no longer set
           <varname>ID_NET_NAME_SLOT</varname> if we detect that a PCI device associated with a slot is a PCI
           bridge as that would create naming conflict when there are more child devices on that bridge. Now,
           this is relaxed and we will use slot information to generate the name based on it but only if


### PR DESCRIPTION
Due to the rebase in 9.2 it is a bit confusing that we are documenting the newer upstream scheme and it might look 9.0 is based in v255. So let's explicitly mention that the scheme is the same as in v251.

Resolves: RHEL-87179

rhel-only: doc