### PR TITLE
(RHEL-100553) flush_ports: flush POSIX message queues properly

### DIFF
--- a/src/basic/socket-util.h
+++ b/src/basic/socket-util.h
@@ -197,6 +197,7 @@ int receive_many_fds(int transport_fd, int **ret_fds_array, size_t *ret_n_fds_ar
 ssize_t next_datagram_size_fd(int fd);
 
 int flush_accept(int fd);
+ssize_t flush_mqueue(int fd);
 
 #define CMSG_FOREACH(cmsg, mh)                                          \
         for ((cmsg) = CMSG_FIRSTHDR(mh); (cmsg); (cmsg) = CMSG_NXTHDR((mh), (cmsg)))

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -2295,8 +2295,12 @@ static void flush_ports(Socket *s) {
                 if (p->fd < 0)
                         continue;
 
-                (void) flush_accept(p->fd);
-                (void) flush_fd(p->fd);
+                if (p->type == SOCKET_MQUEUE)
+                        (void) flush_mqueue(p->fd);
+                else {
+                        (void) flush_accept(p->fd);
+                        (void) flush_fd(p->fd);
+                }
         }
 }
 


### PR DESCRIPTION
On Linux, read() on a message queue descriptor returns the message queue statistics, not the actual message queue data.  We need to use mq_receive() to drain the queues instead.

Fixes a problem where a POSIX message queue socket unit with messages in the queue at shutdown time could result in a hang on reboot/shutdown.

(cherry picked from commit ffb6adb76367d5ab7d43937ccaac5947717b5b78)

Resolves: RHEL-100553

<!-- issue-commentator = {"comment-id":"3008702009"} -->