### PR TITLE
(RHEL-97625) ukify: fix version detection for aarch64 zboot kernels with gzip or lzma compression

### DIFF
--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -164,20 +164,24 @@ def get_zboot_kernel(f: IO[bytes]) -> bytes:
     f.seek(start)
     if comp_type.startswith(b'gzip'):
         gzip = try_import('gzip')
-        return cast(bytes, gzip.open(f).read(size))
+        data = f.read(size)
+        return cast(bytes, gzip.decompress(data))
     elif comp_type.startswith(b'lz4'):
         lz4 = try_import('lz4.frame', 'lz4')
-        return cast(bytes, lz4.frame.decompress(f.read(size)))
+        data = f.read(size)
+        return cast(bytes, lz4.frame.decompress(data))
     elif comp_type.startswith(b'lzma'):
         lzma = try_import('lzma')
-        return cast(bytes, lzma.open(f).read(size))
+        data = f.read(size)
+        return cast(bytes, lzma.decompress(data))
     elif comp_type.startswith(b'lzo'):
         raise NotImplementedError('lzo decompression not implemented')
     elif comp_type.startswith(b'xzkern'):
         raise NotImplementedError('xzkern decompression not implemented')
     elif comp_type.startswith(b'zstd'):
         zstd = try_import('zstandard')
-        return cast(bytes, zstd.ZstdDecompressor().stream_reader(f.read(size)).read())
+        data = f.read(size)
+        return cast(bytes, zstd.ZstdDecompressor().stream_reader(data).read())
 
     raise NotImplementedError(f'unknown compressed type: {comp_type!r}')
 

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -176,8 +176,8 @@ def get_zboot_kernel(f: IO[bytes]) -> bytes:
     elif comp_type.startswith(b'xzkern'):
         raise NotImplementedError('xzkern decompression not implemented')
     elif comp_type.startswith(b'zstd22'):
-        zstd = try_import('zstd')
-        return cast(bytes, zstd.uncompress(f.read(size)))
+        zstd = try_import('zstandard')
+        return cast(bytes, zstd.ZstdDecompressor().stream_reader(f.read(size)).read())
 
     raise NotImplementedError(f'unknown compressed type: {comp_type!r}')
 
@@ -207,8 +207,8 @@ def maybe_decompress(filename: Union[str, Path]) -> bytes:
         return cast(bytes, gzip.open(f).read())
 
     if start.startswith(b'\x28\xb5\x2f\xfd'):
-        zstd = try_import('zstd')
-        return cast(bytes, zstd.uncompress(f.read()))
+        zstd = try_import('zstandard')
+        return cast(bytes, zstd.ZstdDecompressor().stream_reader(f.read()).read())
 
     if start.startswith(b'\x02\x21\x4c\x18'):
         lz4 = try_import('lz4.frame', 'lz4')

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -175,7 +175,7 @@ def get_zboot_kernel(f: IO[bytes]) -> bytes:
         raise NotImplementedError('lzo decompression not implemented')
     elif comp_type.startswith(b'xzkern'):
         raise NotImplementedError('xzkern decompression not implemented')
-    elif comp_type.startswith(b'zstd22'):
+    elif comp_type.startswith(b'zstd'):
         zstd = try_import('zstandard')
         return cast(bytes, zstd.ZstdDecompressor().stream_reader(f.read(size)).read())
 

--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -467,7 +467,7 @@ class SignTool:
         raise NotImplementedError()
 
     @staticmethod
-    def verify(opts: UkifyConfig) -> bool:
+    def verify(input_f: Path, opts: UkifyConfig) -> bool:
         raise NotImplementedError()
 
     @staticmethod
@@ -503,11 +503,11 @@ class PeSign(SignTool):
         subprocess.check_call(cmd)
 
     @staticmethod
-    def verify(opts: UkifyConfig) -> bool:
-        assert opts.linux is not None
+    def verify(input_f: Path, opts: UkifyConfig) -> bool:
+        assert input_f is not None
 
         tool = find_tool('pesign', opts=opts)
-        cmd = [tool, '-i', opts.linux, '-S']
+        cmd = [tool, '-i', input_f, '-S']
 
         print('+', shell_join(cmd), file=sys.stderr)
         info = subprocess.check_output(cmd, text=True)
@@ -535,11 +535,11 @@ class SbSign(SignTool):
         subprocess.check_call(cmd)
 
     @staticmethod
-    def verify(opts: UkifyConfig) -> bool:
-        assert opts.linux is not None
+    def verify(input_f: Path, opts: UkifyConfig) -> bool:
+        assert input_f is not None
 
         tool = find_tool('sbverify', opts=opts)
-        cmd = [tool, '--list', opts.linux]
+        cmd = [tool, '--list', input_f]
 
         print('+', shell_join(cmd), file=sys.stderr)
         info = subprocess.check_output(cmd, text=True)
@@ -587,7 +587,7 @@ class SystemdSbSign(SignTool):
         subprocess.check_call(cmd)
 
     @staticmethod
-    def verify(opts: UkifyConfig) -> bool:
+    def verify(input_f: Path, opts: UkifyConfig) -> bool:
         raise NotImplementedError('systemd-sbsign cannot yet verify if existing PE binaries are signed')
 
 
@@ -1135,7 +1135,7 @@ def make_uki(opts: UkifyConfig) -> None:
 
         if sign_kernel is None:
             # figure out if we should sign the kernel
-            sign_kernel = signtool.verify(opts)
+            sign_kernel = signtool.verify(linux, opts)
 
         if sign_kernel:
             linux_signed = tempfile.NamedTemporaryFile(prefix='linux-signed')


### PR DESCRIPTION
Fixes https://github.com/systemd/systemd/issues/34780. The number in the header
is the size of the *compressed* data, so for gzip we'd read the initial part of
the decompressed data (equal to the size of the compressed data) and not find
the version string. Later on, Fedora switched to zstd compression, and there we
correctly use the number as the size of the compressed data, so we stopped
hitting the issue, but we should still fix it for older kernels.

I verified that the fix works for gzip-compressed kernels. I also made the same
change for the code for lzma compression. I'm pretty sure it is the right thing,
even though I don't have such a kernel at hand to test.

>>> ukify.Uname.scrape('/lib/modules/6.12.0-0.rc2.24.fc42.aarch64/vmlinuz')
Real-Mode Kernel Header magic not found
+ readelf --notes /lib/modules/6.12.0-0.rc2.24.fc42.aarch64/vmlinuz
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
Found uname version: 6.12.0-0.rc2.24.fc42.aarch64

(cherry picked from commit 85830b0d62ac215952774cf07157c113f2f92cae)

Resolves: RHEL-97625

<!-- issue-commentator = {"comment-id":"3069720818"} -->