### PR TITLE
(RHEL-106260) core/transaction: do not attempt to log "n/a" as a journal field

### DIFF
--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -413,7 +413,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                         log_struct(LOG_ERR,
                                    LOG_UNIT_MESSAGE(j->unit, "%s", cycle_path_text),
                                    LOG_MESSAGE_ID(SD_MESSAGE_UNIT_ORDERING_CYCLE_STR),
-                                   LOG_ITEM("%s", strna(unit_ids)));
+                                   LOG_ITEM("%s", strempty(unit_ids)));
 
                 if (delete) {
                         const char *status;
@@ -426,7 +426,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                                    LOG_MESSAGE_ID(SD_MESSAGE_DELETING_JOB_BECAUSE_ORDERING_CYCLE_STR),
                                    LOG_ITEM("DELETED_UNIT=%s", delete->unit->id),
                                    LOG_ITEM("DELETED_TYPE=%s", job_type_to_string(delete->type)),
-                                   LOG_ITEM("%s", strna(unit_ids)));
+                                   LOG_ITEM("%s", strempty(unit_ids)));
 
                         if (log_get_show_color())
                                 status = ANSI_HIGHLIGHT_RED " SKIP " ANSI_NORMAL;
@@ -446,7 +446,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                            LOG_UNIT_MESSAGE(j->unit, "Unable to break cycle starting with %s/%s",
                                             j->unit->id, job_type_to_string(j->type)),
                            LOG_MESSAGE_ID(SD_MESSAGE_CANT_BREAK_ORDERING_CYCLE_STR),
-                           LOG_ITEM("%s", strna(unit_ids)));
+                           LOG_ITEM("%s", strempty(unit_ids)));
 
                 return sd_bus_error_setf(e, BUS_ERROR_TRANSACTION_ORDER_IS_CYCLIC,
                                          "Transaction order is cyclic. See system logs for details.");


### PR DESCRIPTION
Follow-up for 3cf6a3a3d4acf8347ccd0250274f517e6b2e9fe6

(cherry picked from commit 1c8d653d2b8a82ed3944f03c2dea25ad1e2cc967)

Related: RHEL-106260

<!-- issue-commentator = {"comment-id":"3191218588"} -->