### PR TITLE
(RHEL-109552) ukify: rstrip and escape binary null characters from 'inspect' output

### DIFF
--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -1468,7 +1468,7 @@ def inspect_section(
 
     if ttype == 'text':
         try:
-            struct['text'] = data.decode()
+            struct['text'] = data.rstrip(b'\0').replace(b'\0', b'\\0').decode()
         except UnicodeDecodeError as e:
             print(f'Section {name!r} is not valid text: {e}')
             struct['text'] = '(not valid UTF-8)'


### PR DESCRIPTION
SBAT section of UKI may contain \u000 null characters. Rstrip them, and if there's anything left in the middle, escape them so they are displayed as text.

Fixes #38606
(cherry picked from commit 776991a3f349d9c99fd166a0c87fcd2bc1bf92a5)

Resolves: RHEL-109552

<!-- issue-commentator = {"comment-id":"3199057055"} -->