### PR TITLE
(RHEL-108006) chase: check the result is a directory or regular file only when the …

### DIFF
--- a/src/basic/chase.c
+++ b/src/basic/chase.c
@@ -485,16 +485,18 @@ int chaseat(int dir_fd, const char *path, ChaseFlags flags, char **ret_path, int
                 close_and_replace(fd, child);
         }
 
-        if (FLAGS_SET(flags, CHASE_MUST_BE_DIRECTORY)) {
-                r = stat_verify_directory(&st);
-                if (r < 0)
-                        return r;
-        }
+        if (exists) {
+                if (FLAGS_SET(flags, CHASE_MUST_BE_DIRECTORY)) {
+                        r = stat_verify_directory(&st);
+                        if (r < 0)
+                                return r;
+                }
 
-        if (FLAGS_SET(flags, CHASE_MUST_BE_REGULAR)) {
-                r = stat_verify_regular(&st);
-                if (r < 0)
-                        return r;
+                if (FLAGS_SET(flags, CHASE_MUST_BE_REGULAR)) {
+                        r = stat_verify_regular(&st);
+                        if (r < 0)
+                                return r;
+                }
         }
 
         if (ret_path) {


### PR DESCRIPTION
…resolved path exists

Otherwise, if it is called with CHASE_NONEXISTENT, when we call stat_verify_directory()/_regular() the struct stat is for one of the parent directory, rather than for the result path.

With this change, we can safely specify CHASE_MUST_BE_DIRECTORY/REGULAR with CHASE_NONEXISTENT.

More importantly, chaseat() internally sets CHASE_MUST_BE_DIRECTORY when the input path ends with "/", "/,", "/..". Hence, without this change, we cannot specify CHASE_NONEXISTENT safely.

Follow-up for 90b9f7a07e6f57825f416f6ce2db0a9f2086754b.

(cherry picked from commit 1cabb6905b98ecc11bfb1fd8305c8f5c089e5c32)

Resolves: RHEL-108006

<!-- issue-commentator = {"comment-id":"3227506090"} -->