### PR TITLE
TEST-17: drop unnecessary $PATH setting

### DIFF
--- a/test/units/TEST-17-UDEV.11.sh
+++ b/test/units/TEST-17-UDEV.11.sh
@@ -8,8 +8,6 @@ set -o pipefail
 # shellcheck source=test/units/util.sh
 . "$(dirname "$0")"/util.sh
 
-PATH=/var/build:$PATH
-
 # shellcheck disable=SC2317
 cleanup() {
     cd /


### PR DESCRIPTION
My local setting was unintentionally inserted by the commit 7cb4508c5af465ab1be1b103e6c2b613eb58e63c.

(cherry picked from commit da9d75e0c6f6ae1e70e2f7efb8adb3851926e220)

Resolves: RHEL-108242