### PR TITLE
(RHEL-113920) coredump: drop RestrictSUIDSGID= option (#38640)

### DIFF
--- a/units/systemd-coredump@.service.in
+++ b/units/systemd-coredump@.service.in
@@ -36,7 +36,6 @@ ProtectKernelLogs=yes
 ProtectSystem=strict
 RestrictAddressFamilies=AF_UNIX
 RestrictRealtime=yes
-RestrictSUIDSGID=yes
 RuntimeMaxSec=5min
 StateDirectory=systemd/coredump
 SystemCallArchitectures=native


### PR DESCRIPTION
systemd-coredump sandbox already has ProtectSystem=strict hence all non API filesystems are made read-only, thus RestrictSUIDSGID= doesn't buy us much.

On top of that systemd-coredump's EnterNamespace= feature requires openat2() to work correctly and that is implicitly blocked by RestrictSUIDSGID=.

Follow-up for 8f8148cb08bf9f2c0e1f7fe6a5e6eb383115957b

(cherry picked from commit fb56da5b6eb80f4400ea7241fa98d90d245d7fde)

Resolves: RHEL-113920