### PR TITLE
(RHEL-114414) ukify: fix insertion of padding in merged sections

### DIFF
--- a/src/ukify/ukify.py
+++ b/src/ukify/ukify.py
@@ -956,14 +956,13 @@ def pe_add_sections(uki: UKI, output: str) -> None:
                 if new_section.Misc_VirtualSize > s.SizeOfRawData:
                     raise PEError(f'Not enough space in existing section {section.name} to append new data.')
 
-                padding = bytes(new_section.SizeOfRawData - new_section.Misc_VirtualSize)
+                padding = bytes(s.SizeOfRawData - new_section.Misc_VirtualSize)
                 pe.__data__ = (
                     pe.__data__[: s.PointerToRawData]
                     + data
                     + padding
                     + pe.__data__[pe.sections[i + 1].PointerToRawData :]
                 )
-                s.SizeOfRawData = new_section.SizeOfRawData
                 s.Misc_VirtualSize = new_section.Misc_VirtualSize
                 break
         else:


### PR DESCRIPTION
The padding was done to expand the new section contents to the expected size of the new section. And this then would be used for the content in the existing section. The new section cannot be larger than the old section, but it can be smaller. If the new section was smaller, then we'd not write enough padding and the output file would be corrupted.

This was observed in CI when the .sbat section in the stub was padded to 1k. The UKI with an .sbat section that was merged and was fairly short would hit this scenario and be corrupted.

(cherry picked from commit ec1d031f3de02f84beca89e2b402d085fba62be4)

Resolves: RHEL-114414

/cc @DaanDeMeyer

<!-- issue-commentator = {"comment-id":"3284766633"} -->