### PR TITLE
ci: pin Packit/mkosi to the latest RHEL 10.1 commit

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - run: sudo apt-get update
       - uses: systemd/mkosi@d501139032aa659fa8d34bdb850f4eb6b5f458ed
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space

--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -83,6 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - run: sudo apt-get update
       - uses: systemd/mkosi@d501139032aa659fa8d34bdb850f4eb6b5f458ed
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space

--- a/.packit.yml
+++ b/.packit.yml
@@ -24,7 +24,8 @@ actions:
 
   post-upstream-clone:
     # Use the CentOS Stream 10 specfile
-    - "git clone -b c10s https://gitlab.com/redhat/centos-stream/rpms/systemd.git .packit_rpm --depth=1"
+    # Pin this to the latest 10.1 version (systemd-257-13)
+    - "git clone https://gitlab.com/redhat/centos-stream/rpms/systemd.git .packit_rpm --depth=1 --revision=8adcfa40b029b11bb2512c8cc7e6301ee3a77df9"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
     # Drop all patches, since they're already included in the tarball

--- a/mkosi.images/build/mkosi.conf.d/centos-fedora/mkosi.conf
+++ b/mkosi.images/build/mkosi.conf.d/centos-fedora/mkosi.conf
@@ -8,7 +8,8 @@ Distribution=|fedora
 Environment=
         GIT_URL=https://gitlab.com/redhat/centos-stream/rpms/systemd/
         GIT_BRANCH=c10s
-        GIT_COMMIT=c10s
+        # Pin this to the latest 10.1 version (systemd-257-13)
+        GIT_COMMIT=8adcfa40b029b11bb2512c8cc7e6301ee3a77df9
         PKG_SUBDIR=fedora
 
 [Content]


### PR DESCRIPTION
rhel-only
Related: TBD

---

Let's build the RPMs in the 10.1 branch with the 10.1 spec file, since the 10.2 spec file introduced some changes into the build system that are missing from the 10.1 systemd.

<!-- issue-commentator = {"comment-id":"3745559977"} -->