### PR TITLE
(RHEL-143728) core: only activate transaction that contain useful jobs

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -2297,6 +2297,11 @@ int manager_propagate_reload(Manager *m, Unit *unit, JobMode mode, sd_bus_error 
                         tr->anchor_job,
                         mode == JOB_IGNORE_DEPENDENCIES ? TRANSACTION_IGNORE_ORDER : 0);
 
+        /* Only activate the transaction if it contains jobs other than NOP anchor.
+         * Short-circuiting here avoids unnecessary processing, such as emitting D-Bus signals. */
+        if (hashmap_size(tr->jobs) <= 1)
+                return 0;
+
         r = transaction_activate(tr, m, mode, NULL, e);
         if (r < 0)
                 return r;


### PR DESCRIPTION
If no real jobs were added to the transaction, do not activate it. The JOB_NOP anchor does not perform any useful work and activating such transaction only wastes resources.

Fixes #9751

(cherry picked from commit bcbf80c43d107ad233edc990a60bdc40f517085a)

Resolves: RHEL-143728

<!-- issue-commentator = {"comment-id":"3928152858"} -->