### PR TITLE
(RHEL-158354) Add some hardening around attr. handling to various udev `*_id` tools

### DIFF
--- a/src/shared/device-nodes.c
+++ b/src/shared/device-nodes.c
@@ -7,6 +7,7 @@
 
 #include "device-nodes.h"
 #include "path-util.h"
+#include "stdio-util.h"
 #include "string-util.h"
 #include "utf8.h"
 
@@ -39,10 +40,10 @@ int encode_devnode_name(const char *str, char *str_enc, size_t len) {
 
                 } else if (str[i] == '\\' || !allow_listed_char_for_devnode(str[i], NULL)) {
 
-                        if (len-j < 4)
+                        if (len-j < 5)
                                 return -EINVAL;
 
-                        sprintf(&str_enc[j], "\\x%02x", (unsigned char) str[i]);
+                        assert_se(snprintf_ok(&str_enc[j], 5, "\\x%02x", (unsigned char) str[i]));
                         j += 4;
 
                 } else {

--- a/src/udev/dmi_memory_id/dmi_memory_id.c
+++ b/src/udev/dmi_memory_id/dmi_memory_id.c
@@ -51,6 +51,7 @@
 #include "string-util.h"
 #include "udev-util.h"
 #include "unaligned.h"
+#include "utf8.h"
 
 #define SUPPORTED_SMBIOS_VER 0x030300
 
@@ -185,7 +186,7 @@ static void dmi_memory_device_string(
 
         str = strdupa_safe(dmi_string(h, s));
         str = strstrip(str);
-        if (!isempty(str))
+        if (!isempty(str) && utf8_is_valid(str) && !string_has_cc(str, /* ok= */ NULL))
                 printf("MEMORY_DEVICE_%u_%s=%s\n", slot_num, attr_suffix, str);
 }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -27,6 +27,7 @@
 #include "strv.h"
 #include "strxcpyx.h"
 #include "udev-util.h"
+#include "utf8.h"
 
 static const struct option options[] = {
         { "device",             required_argument, NULL, 'd' },
@@ -450,8 +451,8 @@ static int scsi_id(char *maj_min_dev) {
                 }
                 if (dev_scsi.tgpt_group[0] != '\0')
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
-                if (dev_scsi.unit_serial_number[0] != '\0')
-                        printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
+                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                        printf("ID_SCSI_SERIAL=%s\n", serial_str);
                 goto out;
         }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -452,7 +452,7 @@ static int scsi_id(char *maj_min_dev) {
                 if (dev_scsi.tgpt_group[0] != '\0')
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
                 if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
-                        printf("ID_SCSI_SERIAL=%s\n", serial_str);
+                        printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
                 goto out;
         }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -398,6 +398,10 @@ static int set_inq_values(struct scsi_id_device *dev_scsi, const char *path) {
         return 0;
 }
 
+static bool scsi_string_is_valid(const char *s) {
+        return !isempty(s) && utf8_is_valid(s) && !string_has_cc(s, /* ok= */ NULL);
+}
+
 /*
  * scsi_id: try to get an id, if one is found, printf it to stdout.
  * returns a value passed to exit() - 0 if printed an id, else 1.
@@ -441,17 +445,17 @@ static int scsi_id(char *maj_min_dev) {
                         udev_replace_chars(serial_str, NULL);
                         printf("ID_SERIAL_SHORT=%s\n", serial_str);
                 }
-                if (dev_scsi.wwn[0] != '\0') {
+                if (scsi_string_is_valid(dev_scsi.wwn)) {
                         printf("ID_WWN=0x%s\n", dev_scsi.wwn);
-                        if (dev_scsi.wwn_vendor_extension[0] != '\0') {
+                        if (scsi_string_is_valid(dev_scsi.wwn_vendor_extension)) {
                                 printf("ID_WWN_VENDOR_EXTENSION=0x%s\n", dev_scsi.wwn_vendor_extension);
                                 printf("ID_WWN_WITH_EXTENSION=0x%s%s\n", dev_scsi.wwn, dev_scsi.wwn_vendor_extension);
                         } else
                                 printf("ID_WWN_WITH_EXTENSION=0x%s\n", dev_scsi.wwn);
                 }
-                if (dev_scsi.tgpt_group[0] != '\0')
+                if (scsi_string_is_valid(dev_scsi.tgpt_group))
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
-                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                if (scsi_string_is_valid(dev_scsi.unit_serial_number))
                         printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
                 goto out;
         }

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -40,6 +40,7 @@
 #include "strv.h"
 #include "strxcpyx.h"
 #include "udev-builtin.h"
+#include "utf8.h"
 
 #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
 #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
@@ -236,6 +237,9 @@ static int get_port_specifier(sd_device *dev, bool fallback_to_dev_id, char **re
                         }
                 }
 
+                if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
+                        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
+
                 /* Otherwise, use phys_port_name as is. */
                 buf = strjoin("n", phys_port_name);
                 if (!buf)
@@ -339,6 +343,9 @@ static int names_pci_onboard_label(UdevEvent *event, sd_device *pci_dev, const c
         r = device_get_sysattr_value_filtered(pci_dev, "label", &label);
         if (r < 0)
                 return log_device_debug_errno(pci_dev, r, "Failed to get PCI onboard label: %m");
+
+        if (!utf8_is_valid(label) || string_has_cc(label, /* ok= */ NULL))
+                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid label");
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%s%s",
@@ -1257,6 +1264,8 @@ static int names_netdevsim(UdevEvent *event, const char *prefix) {
         if (isempty(phys_port_name))
                 return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EOPNOTSUPP),
                                               "The 'phys_port_name' attribute is empty.");
+        if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
+                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%si%un%s", prefix, addr, phys_port_name))

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -28,6 +28,7 @@
 #include "device-private.h"
 #include "device-util.h"
 #include "dirent-util.h"
+#include "escape.h"
 #include "ether-addr-util.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -44,6 +45,12 @@
 
 #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
 #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
+
+static int log_invalid_device_attr(sd_device *dev, const char *attr, const char *value) {
+        _cleanup_free_ char *escaped = cescape(value);
+        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL),
+                                      "Invalid %s value '%s'.", attr, strnull(escaped));
+}
 
 /* skip intermediate virtio devices */
 static sd_device *device_skip_virtio(sd_device *dev) {
@@ -238,7 +245,7 @@ static int get_port_specifier(sd_device *dev, bool fallback_to_dev_id, char **re
                 }
 
                 if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
-                        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
+                        return log_invalid_device_attr(dev, "phys_port_name", phys_port_name);
 
                 /* Otherwise, use phys_port_name as is. */
                 buf = strjoin("n", phys_port_name);
@@ -345,7 +352,7 @@ static int names_pci_onboard_label(UdevEvent *event, sd_device *pci_dev, const c
                 return log_device_debug_errno(pci_dev, r, "Failed to get PCI onboard label: %m");
 
         if (!utf8_is_valid(label) || string_has_cc(label, /* ok= */ NULL))
-                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid label");
+                return log_invalid_device_attr(dev, "label", label);
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%s%s",
@@ -751,8 +758,7 @@ static int names_vio(UdevEvent *event, const char *prefix) {
                                               "VIO bus ID and slot ID have invalid length: %s", s);
 
         if (!in_charset(s, HEXDIGITS))
-                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL),
-                                              "VIO bus ID and slot ID contain invalid characters: %s", s);
+                return log_invalid_device_attr(dev, "VIO bus ID and slot ID", s);
 
         /* Parse only slot ID (the last 4 hexdigits). */
         r = safe_atou_full(s + 4, 16, &slotid);
@@ -808,8 +814,7 @@ static int names_platform(UdevEvent *event, const char *prefix) {
                 return -EOPNOTSUPP;
 
         if (!in_charset(vendor, validchars))
-                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(ENOENT),
-                                              "Platform vendor contains invalid characters: %s", vendor);
+                return log_invalid_device_attr(dev, "platform vendor", vendor);
 
         ascii_strlower(vendor);
 
@@ -1265,7 +1270,7 @@ static int names_netdevsim(UdevEvent *event, const char *prefix) {
                 return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EOPNOTSUPP),
                                               "The 'phys_port_name' attribute is empty.");
         if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
-                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
+                return log_invalid_device_attr(dev, "phys_port_name", phys_port_name);
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%si%un%s", prefix, addr, phys_port_name))

--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -667,7 +667,7 @@ static void add_id_tag(UdevEvent *event, const char *path) {
         size_t i = 0;
 
         /* compose valid udev tag name */
-        for (const char *p = path; *p; p++) {
+        for (const char *p = path; *p && i < sizeof(tag) - 1; p++) {
                 if (ascii_isdigit(*p) ||
                     ascii_isalpha(*p) ||
                     *p == '-') {

--- a/src/udev/v4l_id/v4l_id.c
+++ b/src/udev/v4l_id/v4l_id.c
@@ -19,6 +19,8 @@
 #include "build.h"
 #include "fd-util.h"
 #include "main-func.h"
+#include "string-util.h"
+#include "utf8.h"
 
 static const char *arg_device = NULL;
 
@@ -72,7 +74,8 @@ static int run(int argc, char *argv[]) {
                 int capabilities;
 
                 printf("ID_V4L_VERSION=2\n");
-                printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
+                if (utf8_is_valid((char *)v2cap.card) && !string_has_cc((char *)v2cap.card, /* ok= */ NULL))
+                        printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
                 printf("ID_V4L_CAPABILITIES=:");
 
                 if (v2cap.capabilities & V4L2_CAP_DEVICE_CAPS)


### PR DESCRIPTION
Resolves: RHEL-158354

<!-- issue-commentator = {"comment-id":"4222351260"} -->