### PR TITLE
(RHEL-168098) journald: extend STDOUT_STREAMS_MAX to 64k

### DIFF
--- a/src/journal/journald-stream.c
+++ b/src/journal/journald-stream.c
@@ -40,7 +40,7 @@
 #include "unit-name.h"
 #include "user-util.h"
 
-#define STDOUT_STREAMS_MAX 4096
+#define STDOUT_STREAMS_MAX (64*1024)
 
 /* During the "setup" protocol phase of the stream logic let's define a different maximum line length than
  * during the actual operational phase. We want to allow users to specify very short line lengths after all,


### PR DESCRIPTION
Closes #35390.

(cherry picked from commit c576ba7182f54f352c03f0768c9178b173fb8bcb)

<!-- issue-commentator = {"comment-id":"4251630187"} -->