### PR TITLE
(RHEL-153030) Enable uaccess tagging for KFD and ACCEL devices

### DIFF
--- a/rules.d/70-uaccess.rules.in
+++ b/rules.d/70-uaccess.rules.in
@@ -47,6 +47,8 @@ SUBSYSTEM=="drm", KERNEL=="card*", TAG+="uaccess"
 {% if GROUP_RENDER_UACCESS %}
 # DRI render nodes
 SUBSYSTEM=="drm", KERNEL=="renderD*", TAG+="uaccess"
+# DRI accel nodes
+SUBSYSTEM=="accel", KERNEL=="accel*", TAG+="uaccess", TAG+="xaccess-accel"
 {% endif %}
 {% if DEV_KVM_UACCESS %}
 # KVM

--- a/rules.d/70-uaccess.rules.in
+++ b/rules.d/70-uaccess.rules.in
@@ -49,6 +49,8 @@ SUBSYSTEM=="drm", KERNEL=="card*", TAG+="uaccess"
 SUBSYSTEM=="drm", KERNEL=="renderD*", TAG+="uaccess"
 # DRI accel nodes
 SUBSYSTEM=="accel", KERNEL=="accel*", TAG+="uaccess", TAG+="xaccess-accel"
+# AMD KFD nodes
+SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", TAG+="xaccess-render"
 {% endif %}
 {% if DEV_KVM_UACCESS %}
 # KVM


### PR DESCRIPTION
Resolves: RHEL-153030

<!-- issue-commentator = {"comment-id":"4288674898"} -->