### PR TITLE
(RHEL-155454) A couple of ASan-related tweaks

### DIFF
--- a/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi.sanitizers/mkosi.postinst
@@ -114,8 +114,11 @@ for bin in "${wrap[@]}"; do
 # Preload the ASan runtime DSO, otherwise ASAn will complain
 export LD_PRELOAD="$ASAN_RT_PATH"
 # Disable LSan to speed things up, since we don't care about leak reports
-# from 'external' binaries
-export ASAN_OPTIONS=detect_leaks=$enable_lsan
+# from 'external' binaries. In addition, disable quarantine (for use-after-free
+# detection) and malloc stack frame collection as we don't care about these in
+# 'external' binaries either, and they just unnecessarily hog up memory & cpu
+# cycles.
+export ASAN_OPTIONS=detect_leaks=$enable_lsan:quarantine_size_mb=0:malloc_context_size=0
 # Set argv[0] to the original binary name without the ".orig" suffix
 exec -a "\$0" -- "${target}.orig" "\$@"
 EOF

--- a/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi.sanitizers/mkosi.postinst
@@ -65,6 +65,7 @@ wrap=(
     mdadm
     mkfs.btrfs
     mksquashfs
+    mount
     multipath
     multipathd
     nvme
@@ -78,6 +79,7 @@ wrap=(
     su
     tar
     tgtd
+    umount
     useradd
     userdel
     veritysetup

--- a/mkosi.sanitizers/mkosi.postinst
+++ b/mkosi.sanitizers/mkosi.postinst
@@ -44,6 +44,7 @@ wrap=(
     dbus-broker-launch
     dbus-daemon
     delv
+    dfuzzer
     dhcpd
     dig
     dnf
@@ -55,17 +56,21 @@ wrap=(
     getfacl
     id
     integritysetup
+    iscsiadm
     iscsid
     kpartx
     logger
     login
     ls
     lsblk
+    lsns
     lvm
     mdadm
     mkfs.btrfs
+    mkfs.ext4
     mksquashfs
     mount
+    mountpoint
     multipath
     multipathd
     nvme
@@ -77,8 +82,12 @@ wrap=(
     sshd
     stat
     su
+    swapoff
+    swapon
     tar
     tgtd
+    # The tpm2 tools (tpm2_readpublic, tpm2_pcrextend, ...) all are symlinks to tpm2
+    tpm2
     umount
     useradd
     userdel

--- a/src/systemd/_sd-common.h
+++ b/src/systemd/_sd-common.h
@@ -45,10 +45,6 @@ typedef void (*_sd_destroy_t)(void *userdata);
 #  define _sd_pure_ __attribute__((__pure__))
 #endif
 
-#ifndef _sd_const_
-#  define _sd_const_ __attribute__((__const__))
-#endif
-
 /* Note that strictly speaking __deprecated__ has been available before GCC 6. However, starting with GCC 6
  * it also works on enum values, which we are interested in. Since this is a developer-facing feature anyway
  * (as opposed to build engineer-facing), let's hence conditionalize this to gcc 6, given that the developers

--- a/src/systemd/sd-id128.h
+++ b/src/systemd/sd-id128.h
@@ -134,7 +134,7 @@ static __inline__ int sd_id128_is_allf(sd_id128_t a) {
 #define SD_ID128_NULL ((const sd_id128_t) { .qwords = { 0, 0 }})
 #define SD_ID128_ALLF ((const sd_id128_t) { .qwords = { UINT64_C(0xFFFFFFFFFFFFFFFF), UINT64_C(0xFFFFFFFFFFFFFFFF) }})
 
-_sd_const_ static __inline__ int sd_id128_in_setv(sd_id128_t a, va_list ap) {
+static __inline__ int sd_id128_in_setv(sd_id128_t a, va_list ap) {
         for (;;) {
                 sd_id128_t b = va_arg(ap, sd_id128_t);
 

--- a/src/systemd/sd-id128.h
+++ b/src/systemd/sd-id128.h
@@ -117,17 +117,17 @@ int sd_id128_get_invocation_app_specific(sd_id128_t app_id, sd_id128_t *ret);
 #define SD_ID128_MAKE_UUID_STR(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) \
         #a #b #c #d "-" #e #f "-" #g #h "-" #i #j "-" #k #l #m #n #o #p
 
-_sd_const_ static __inline__ int sd_id128_equal(sd_id128_t a, sd_id128_t b) {
+static __inline__ int sd_id128_equal(sd_id128_t a, sd_id128_t b) {
         return a.qwords[0] == b.qwords[0] && a.qwords[1] == b.qwords[1];
 }
 
 int sd_id128_string_equal(const char *s, sd_id128_t id);
 
-_sd_const_ static __inline__ int sd_id128_is_null(sd_id128_t a) {
+static __inline__ int sd_id128_is_null(sd_id128_t a) {
         return a.qwords[0] == 0 && a.qwords[1] == 0;
 }
 
-_sd_const_ static __inline__ int sd_id128_is_allf(sd_id128_t a) {
+static __inline__ int sd_id128_is_allf(sd_id128_t a) {
         return a.qwords[0] == UINT64_C(0xFFFFFFFFFFFFFFFF) && a.qwords[1] == UINT64_C(0xFFFFFFFFFFFFFFFF);
 }
 
@@ -146,7 +146,7 @@ _sd_const_ static __inline__ int sd_id128_in_setv(sd_id128_t a, va_list ap) {
         }
 }
 
-_sd_const_ static __inline__ int sd_id128_in_set_sentinel(sd_id128_t a, ...) {
+static __inline__ int sd_id128_in_set_sentinel(sd_id128_t a, ...) {
         va_list ap;
         int r;
 

--- a/src/systemd/sd-json.h
+++ b/src/systemd/sd-json.h
@@ -339,7 +339,7 @@ int sd_json_variant_strv(sd_json_variant *v, char ***ret);
 int sd_json_variant_unbase64(sd_json_variant *v, void **ret, size_t *ret_size);
 int sd_json_variant_unhex(sd_json_variant *v, void **ret, size_t *ret_size);
 
-_sd_const_ static __inline__ int sd_json_format_enabled(sd_json_format_flags_t flags) {
+static __inline__ int sd_json_format_enabled(sd_json_format_flags_t flags) {
         return !(flags & SD_JSON_FORMAT_OFF);
 }
 

--- a/test/integration-test-wrapper.py
+++ b/test/integration-test-wrapper.py
@@ -136,7 +136,19 @@ def process_sanitizer_report(args: argparse.Namespace, journal_file: Path) -> bo
     fatal_end = re.compile(r'==[0-9]+==HINT:\s+\w+Sanitizer')
 
     # 'Standard' errors:
-    standard_begin = re.compile(r'([0-9]+: runtime error|==[0-9]+==.+?\w+Sanitizer)')
+    #
+    # TODO: there's currently a bug in LLVM 22 due to which certain systemd
+    # units can throw the following warning:
+    # [ 3366.747202] systemd-oomd[93]: ==93==WARNING: ptrace appears to be blocked (is seccomp enabled?).
+    #                LeakSanitizer may hang.
+    # [ 3366.747202] systemd-oomd[93]: ==93==Child exited with signal 15.
+    #
+    # which is then picked up by the following regex and causes the test to
+    # fail. Let's, temporarily, exclude this warning from the regex to mitigate
+    # this.
+    #
+    # See: https://github.com/llvm/llvm-project/issues/193714
+    standard_begin = re.compile(r'([0-9]+: runtime error|==[0-9]+==(?!WARNING: ptrace).+?\w+Sanitizer)')
     standard_end = re.compile(r'SUMMARY:\s+(\w+)Sanitizer')
 
     # extract COMM


### PR DESCRIPTION
This finally fixes our ASan+UBSan job. There was a couple of issues:

  - the first two commits fix a couple of false assumption that given functions are either const
 or pure - this has confused ASan and it kept claiming there's a stack-buffer-underflow. With LLVM 22 it finally managed to generate a full stack trace instead of failing immediately, which helped cherry-picking the correct fixes:

```
[   19.640207] systemd-udevd[598]: ==598==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7ffc9b50f5a0 at pc 0x55969a735540 bp 0x7ffc9b50f1d0 sp 0x7ffc9b50f1c8
[   19.640207] systemd-udevd[598]: READ of size 8 at 0x7ffc9b50f5a0 thread T0 ((udev-worker))
[  184.903079] systemd-udevd[598]:     #0 0x55969a73553f in sd_id128_in_setv /usr/src/debug/systemd/src/systemd/sd-id128.h:139:32
[  184.903079] systemd-udevd[598]:     #1 0x55969a73553f in sd_id128_in_set_sentinel /usr/src/debug/systemd/src/systemd/sd-id128.h:154:13
[  184.903079] systemd-udevd[598]:     #2 0x55969a73479e in find_gpt_root /usr/src/debug/systemd/src/udev/udev-builtin-blkid.c:173:21
[  184.903079] systemd-udevd[598]:     #3 0x55969a733123 in builtin_blkid /usr/src/debug/systemd/src/udev/udev-builtin-blkid.c:441:17
[  184.903079] systemd-udevd[598]:     #4 0x55969a656d38 in udev_builtin_run /usr/src/debug/systemd/src/udev/udev-builtin.c:137:16
[  184.903079] systemd-udevd[598]:     #5 0x55969a6ecc19 in udev_rule_apply_token_to_event /usr/src/debug/systemd/src/udev/udev-rules.c:2494:21
[  184.903079] systemd-udevd[598]:     #6 0x55969a6ca2a8 in udev_rule_apply_line_to_event /usr/src/debug/systemd/src/udev/udev-rules.c:3154:21
[  184.903079] systemd-udevd[598]:     #7 0x55969a6ca2a8 in udev_rules_apply_to_event /usr/src/debug/systemd/src/udev/udev-rules.c:3175:29
[  184.903079] systemd-udevd[598]:     #8 0x55969a69d868 in udev_event_execute_rules /usr/src/debug/systemd/src/udev/udev-event.c:410:13
[  184.903079] systemd-udevd[598]:     #9 0x55969a72f7c5 in worker_process_device /usr/src/debug/systemd/src/udev/udev-worker.c:208:13
[  184.903079] systemd-udevd[598]:     #10 0x55969a72f7c5 in worker_device_monitor_handler /usr/src/debug/systemd/src/udev/udev-worker.c:308:13
[  184.903079] systemd-udevd[598]:     #11 0x7f4d642c40ac in device_monitor_event_handler /usr/src/debug/systemd/src/libsystemd/sd-device/device-monitor.c:334:24
[  184.903079] systemd-udevd[598]:     #12 0x7f4d641a9942 in source_dispatch /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4231:21
[  184.903079] systemd-udevd[598]:     #13 0x7f4d641a7fd2 in sd_event_dispatch /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4852:21
[  184.903079] systemd-udevd[598]:     #14 0x7f4d641ac1a7 in sd_event_run /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4913:21
[  184.903079] systemd-udevd[598]:     #15 0x7f4d641aca4d in sd_event_loop /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4934:21
[  184.903079] systemd-udevd[598]:     #16 0x55969a72e59d in udev_worker_main /usr/src/debug/systemd/src/udev/udev-worker.c:364:13
[  184.903079] systemd-udevd[598]:     #17 0x55969a6ac52b in worker_spawn /usr/src/debug/systemd/src/udev/udev-manager.c:415:21
[  184.903079] systemd-udevd[598]:     #18 0x55969a6ac52b in event_run /usr/src/debug/systemd/src/udev/udev-manager.c:474:13
[  184.905111] systemd-udevd[598]:     #19 0x55969a6ac52b in event_queue_start /usr/src/debug/systemd/src/udev/udev-manager.c:604:21
[  184.905111] systemd-udevd[598]:     #20 0x55969a6a73d6 in on_post /usr/src/debug/systemd/src/udev/udev-manager.c:1083:17
[  184.905111] systemd-udevd[598]:     #21 0x7f4d641a9ce1 in source_dispatch /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c
[  184.905111] systemd-udevd[598]:     #22 0x7f4d641a7fd2 in sd_event_dispatch /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4852:21
[  184.905111] systemd-udevd[598]:     #23 0x7f4d641ac1a7 in sd_event_run /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4913:21
[  184.905111] systemd-udevd[598]:     #24 0x7f4d641aca4d in sd_event_loop /usr/src/debug/systemd/src/libsystemd/sd-event/sd-event.c:4934:21
[  184.905111] systemd-udevd[598]:     #25 0x55969a6a53c2 in manager_main /usr/src/debug/systemd/src/udev/udev-manager.c:1446:13
[  184.905111] systemd-udevd[598]:     #26 0x55969a655afb in run_udevd /usr/src/debug/systemd/src/udev/udevd.c:80:16
[  184.905111] systemd-udevd[598]:     #27 0x55969a654525 in run /usr/src/debug/systemd/src/udev/udevadm.c:125:24
[  184.905111] systemd-udevd[598]:     #28 0x55969a654525 in main /usr/src/debug/systemd/src/udev/udevadm.c:141:1
[  184.905111] systemd-udevd[598]:     #29 0x7f4d635ea58d in __libc_start_call_main (/lib64/libc.so.6+0x2a58d) (BuildId: 53d3d62545b697e3d500b5f04fd7d26c85b4ff4f)
[  184.905111] systemd-udevd[598]:     #30 0x7f4d635ea648 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a648) (BuildId: 53d3d62545b697e3d500b5f04fd7d26c85b4ff4f)
[  184.905111] systemd-udevd[598]:     #31 0x55969a634a44  (/usr/bin/udevadm+0x68a44) (BuildId: aeca29ecf1c9259a950cb2c0722d014b6ac8e010)
[  184.905111] systemd-udevd[598]: Address 0x7ffc9b50f5a0 is located in stack of thread T0 ((udev-worker)) at offset 0 in frame
[  184.905111] systemd-udevd[598]:     #0 0x55969a7317bf in builtin_blkid /usr/src/debug/systemd/src/udev/udev-builtin-blkid.c:321
[  184.905111] systemd-udevd[598]:   This frame has 27 object(s):
[  184.905111] systemd-udevd[598]:     [32, 40) 'fn' (line 255)
[  184.905111] systemd-udevd[598]:     [64, 296) 'info' (line 256)
[  184.905111] systemd-udevd[598]:     [368, 376) 'name' (line 257)
[  184.905111] systemd-udevd[598]:     [400, 448) '_zzq_args' (line 289)
[  184.905111] systemd-udevd[598]:     [480, 736) 's' (line 38)
[  184.905111] systemd-udevd[598]:     [800, 832) '.compoundliteral' (line 38)
[  184.905111] systemd-udevd[598]:     [864, 1008) 'st' (line 215)
[  184.905111] systemd-udevd[598]:     [1072, 1080) 'devnode' (line 323)
[  184.905111] systemd-udevd[598]:     [1104, 1112) 'root_partition' (line 323)
[  184.905111] systemd-udevd[598]:     [1136, 1144) 'data' (line 323)
[  184.905111] systemd-udevd[598]:     [1168, 1176) 'name' (line 323)
[  184.905111] systemd-udevd[598]:     [1200, 1208) 'pr' (line 324)
[  184.905111] systemd-udevd[598]:     [1232, 1240) 'backing_fname' (line 325)
[  184.905111] systemd-udevd[598]:     [1264, 1268) 'fd' (line 327)
[  184.906977] systemd-udevd[598]:     [1280, 1288) 'offset' (line 330)
[  184.906977] systemd-udevd[598]:     [1312, 1320) '_sysname' (line 343)
[  184.906977] systemd-udevd[598]:     [1344, 1352) '_sysname' (line 358)
[  184.906977] systemd-udevd[598]:     [1376, 1384) '_sysname' (line 372)
[  184.906977] systemd-udevd[598]:     [1408, 1416) '_sysname' (line 374)
[  184.906977] systemd-udevd[598]:     [1440, 1448) '_sysname' (line 395)
[  184.906977] systemd-udevd[598]:     [1472, 1480) '_sysname' (line 400)
[  184.906977] systemd-udevd[598]:     [1504, 1512) '_sysname' (line 408)
[  184.906977] systemd-udevd[598]:     [1536, 1544) '_sysname' (line 410)
[  184.906977] systemd-udevd[598]:     [1568, 1576) '_sysname' (line 414)
[  184.906977] systemd-udevd[598]:     [1600, 1608) '_sysname' (line 422)
[  184.906977] systemd-udevd[598]:     [1632, 1640) '_sysname' (line 450)
[  184.906977] systemd-udevd[598]:     [1664, 1921) 'encoded' (line 459)
[  184.906977] systemd-udevd[598]: HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
[  184.906977] systemd-udevd[598]:       (longjmp and C++ exceptions *are* supported)
[  184.906977] systemd-udevd[598]: SUMMARY: AddressSanitizer: stack-buffer-underflow /usr/src/debug/systemd/src/systemd/sd-id128.h:139:32 in sd_id128_in_setv
```

  - wrap a couple more binaries when running with ASan, because util-linux started depending on libsystemd/libudev, and also a couple more libraries/binaries got similar dependecy either directly or transitively
  - LLVM's libasan started throwing a false-positive warning under certain conditions; this has been reported to the upstream, but also worked around in our test suite until it's fixed
  - let's reduce the ASan overhead for wrapped binaries, since for some of them this became a real issue: e.g. dfuzzer, after wrapping, started using way too much memory, since ASan kept track of its allocations, which eventually led to an OOM kill

 
<!-- issue-commentator = {"comment-id":"4295364514"} -->