### PR TITLE
(RHEL-171097) core: cleanup unit's dropin directories from global cache

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -653,6 +653,8 @@ static void unit_remove_transient(Unit *u) {
         if (!u->transient)
                 return;
 
+        const char *dropin_directory = strjoina(u->id, ".d");
+
         STRV_FOREACH(i, u->dropin_paths) {
                 _cleanup_free_ char *p = NULL, *pp = NULL;
 
@@ -665,6 +667,10 @@ static void unit_remove_transient(Unit *u) {
                 /* Only drop transient drop-ins */
                 if (!path_equal(u->manager->lookup_paths.transient, pp))
                         continue;
+
+                /* Drop the transient drop-in directory also from unit path cache. */
+                if (path_equal(last_path_component(p), dropin_directory))
+                        free(set_remove(u->manager->unit_path_cache, p));
 
                 (void) unlink(*i);
                 (void) rmdir(p);


### PR DESCRIPTION
When user creates dropin files via API (e.g. systemctl set-property ...) we put the dropin directory path into unit_path_cache. Drop those directories from the cache in unit_free() and prevent memory leak.

Follow-up for fce94c5c563b8f6ede2b8f7f283d2d2faff4e062.

(cherry picked from commit 0c98e432d1def1e8428dbead50dc629ed0645366)

Resolves: RHEL-171097

<!-- issue-commentator = {"comment-id":"4327532226"} -->