### PR TITLE
(RHEL-180917) udevadm: gracefully handle when a maked file is specified to udevadm …

### DIFF
--- a/src/udev/udevadm-util.c
+++ b/src/udev/udevadm-util.c
@@ -149,6 +149,12 @@ static int search_rules_file_in_conf_dirs(const char *s, const char *root, char 
                 if (!path)
                         return log_oom();
 
+                r = null_or_empty_path_with_root(path, root);
+                if (r > 0) {
+                        log_warning("File '%s%s' is a mask, ignoring.", empty_to_root(root), skip_leading_slash(path));
+                        return 1; /* Found masked file. */
+                }
+
                 r = chase(path, root, CHASE_PREFIX_ROOT | CHASE_MUST_BE_REGULAR, &resolved, /* ret_fd = */ NULL);
                 if (r == -ENOENT)
                         continue;
@@ -182,6 +188,11 @@ static int search_rules_file(const char *s, const char *root, char ***files) {
         r = chase_and_stat(s, root, CHASE_PREFIX_ROOT, &resolved, &st);
         if (r < 0)
                 return log_error_errno(r, "Failed to chase \"%s\": %m", s);
+
+        if (null_or_empty(&st)) {
+                log_warning("File '%s%s' is a mask, ignoring.", empty_to_root(root), skip_leading_slash(s));
+                return 0; /* Found masked file. */
+        }
 
         r = stat_verify_regular(&st);
         if (r == -EISDIR) {

--- a/test/units/TEST-17-UDEV.10.sh
+++ b/test/units/TEST-17-UDEV.10.sh
@@ -38,7 +38,7 @@ udevadm cat 99-systemd
 udevadm cat 99-systemd.rules
 udevadm cat /usr/lib/udev/rules.d/99-systemd.rules
 udevadm cat /usr/lib/udev/rules.d
-(! udevadm cat /dev/null)
+udevadm cat /dev/null
 udevadm cat --config
 udevadm cat -h
 

--- a/test/units/TEST-17-UDEV.11.sh
+++ b/test/units/TEST-17-UDEV.11.sh
@@ -116,8 +116,7 @@ assert_1 --resolve-names=now
 assert_1 ./nosuchfile
 # Failed to parse rules file ./nosuchfile: No such file or directory
 assert_1 ./nosuchfile /dev/null
-# '/dev/null' is neither a regular file nor a directory: File descriptor in bad state
-assert_1 /dev/null
+assert_0 /dev/null
 
 rules_dir='etc/udev/rules.d'
 mkdir -p "${rules_dir}"


### PR DESCRIPTION
…verify/cat

Previously, since 7cb4508c5af465ab1be1b103e6c2b613eb58e63c, if a masked file is specified, the commands failed.
Let's warn that the file is masked and ignore the file.

(cherry picked from commit 782569afd05b97143938ec294b5a28b4f2ffb75c)

Resolves: RHEL-180917

<!-- issue-commentator = {"comment-id":"4843036380"} -->