### PR TITLE
(RHEL-180922) Revert "udev-builtin-net-id: print cescaped bad attributes"

### DIFF
--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -28,7 +28,6 @@
 #include "device-private.h"
 #include "device-util.h"
 #include "dirent-util.h"
-#include "escape.h"
 #include "ether-addr-util.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -45,12 +44,6 @@
 
 #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
 #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
-
-static int log_invalid_device_attr(sd_device *dev, const char *attr, const char *value) {
-        _cleanup_free_ char *escaped = cescape(value);
-        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL),
-                                      "Invalid %s value '%s'.", attr, strnull(escaped));
-}
 
 /* skip intermediate virtio devices */
 static sd_device *device_skip_virtio(sd_device *dev) {
@@ -245,7 +238,7 @@ static int get_port_specifier(sd_device *dev, bool fallback_to_dev_id, char **re
                 }
 
                 if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
-                        return log_invalid_device_attr(dev, "phys_port_name", phys_port_name);
+                        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
 
                 /* Otherwise, use phys_port_name as is. */
                 buf = strjoin("n", phys_port_name);
@@ -352,7 +345,7 @@ static int names_pci_onboard_label(UdevEvent *event, sd_device *pci_dev, const c
                 return log_device_debug_errno(pci_dev, r, "Failed to get PCI onboard label: %m");
 
         if (!utf8_is_valid(label) || string_has_cc(label, /* ok= */ NULL))
-                return log_invalid_device_attr(dev, "label", label);
+                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid label");
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%s%s",
@@ -758,7 +751,8 @@ static int names_vio(UdevEvent *event, const char *prefix) {
                                               "VIO bus ID and slot ID have invalid length: %s", s);
 
         if (!in_charset(s, HEXDIGITS))
-                return log_invalid_device_attr(dev, "VIO bus ID and slot ID", s);
+                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL),
+                                              "VIO bus ID and slot ID contain invalid characters: %s", s);
 
         /* Parse only slot ID (the last 4 hexdigits). */
         r = safe_atou_full(s + 4, 16, &slotid);
@@ -814,7 +808,8 @@ static int names_platform(UdevEvent *event, const char *prefix) {
                 return -EOPNOTSUPP;
 
         if (!in_charset(vendor, validchars))
-                return log_invalid_device_attr(dev, "platform vendor", vendor);
+                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(ENOENT),
+                                              "Platform vendor contains invalid characters: %s", vendor);
 
         ascii_strlower(vendor);
 
@@ -1270,7 +1265,7 @@ static int names_netdevsim(UdevEvent *event, const char *prefix) {
                 return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EOPNOTSUPP),
                                               "The 'phys_port_name' attribute is empty.");
         if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
-                return log_invalid_device_attr(dev, "phys_port_name", phys_port_name);
+                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%si%un%s", prefix, addr, phys_port_name))


### PR DESCRIPTION
This reverts commit 7c4047957ef58744ecfad6d277f7c45d430f6d70.

This is not necessary, as bad characters are already filtered.

(cherry picked from commit c6ea72e39a8d829b1bd65f15f6dd7d1c2b6d04c3)

Resolves: RHEL-180922

<!-- issue-commentator = {"comment-id":"4843450933"} -->