### PR TITLE
(RHEL-180923) udev: drop redundant checks

### DIFF
--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -40,7 +40,6 @@
 #include "strv.h"
 #include "strxcpyx.h"
 #include "udev-builtin.h"
-#include "utf8.h"
 
 #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
 #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
@@ -237,9 +236,6 @@ static int get_port_specifier(sd_device *dev, bool fallback_to_dev_id, char **re
                         }
                 }
 
-                if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
-                        return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
-
                 /* Otherwise, use phys_port_name as is. */
                 buf = strjoin("n", phys_port_name);
                 if (!buf)
@@ -343,9 +339,6 @@ static int names_pci_onboard_label(UdevEvent *event, sd_device *pci_dev, const c
         r = device_get_sysattr_value_filtered(pci_dev, "label", &label);
         if (r < 0)
                 return log_device_debug_errno(pci_dev, r, "Failed to get PCI onboard label: %m");
-
-        if (!utf8_is_valid(label) || string_has_cc(label, /* ok= */ NULL))
-                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid label");
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%s%s",
@@ -1264,8 +1257,6 @@ static int names_netdevsim(UdevEvent *event, const char *prefix) {
         if (isempty(phys_port_name))
                 return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EOPNOTSUPP),
                                               "The 'phys_port_name' attribute is empty.");
-        if (!utf8_is_valid(phys_port_name) || string_has_cc(phys_port_name, /* ok= */ NULL))
-                return log_device_debug_errno(dev, SYNTHETIC_ERRNO(EINVAL), "Invalid phys_port_name");
 
         char str[ALTIFNAMSIZ];
         if (snprintf_ok(str, sizeof str, "%si%un%s", prefix, addr, phys_port_name))

--- a/test/units/TEST-71-HOSTNAME.sh
+++ b/test/units/TEST-71-HOSTNAME.sh
@@ -62,7 +62,7 @@ get_chassis() (
 )
 
 stop_hostnamed() {
-    systemctl stop systemd-hostnamed.service
+    systemctl stop --job-mode=replace-irreversibly systemd-hostnamed.service
     # Reset trigger limit. This might fail if the unit was unloaded already, so ignore any errors.
     systemctl reset-failed systemd-hostnamed || :
 }


### PR DESCRIPTION
This partially reverts 16325b35fa6ecb25f66534a562583ce3b96d52f3, as bad characters are already filtered.

(cherry picked from commit c5a04f59d912fb2c3451994279dea3ae3064f6c7)

Resolves: RHEL-180923

<!-- issue-commentator = {"comment-id":"4843743458"} -->