### PR TITLE
(RHEL-180924) homectl: apply all --member-of= groups from a comma-separated list

### DIFF
--- a/src/home/homectl.c
+++ b/src/home/homectl.c
@@ -4080,7 +4080,7 @@ static int parse_argv(int argc, char *argv[]) {
                                 if (!valid_user_group_name(word, 0))
                                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Invalid group name %s.", word);
 
-                                mo = sd_json_variant_ref(sd_json_variant_by_key(arg_identity_extra, "memberOf"));
+                                mo = sd_json_variant_ref(sd_json_variant_by_key(*(match_identity ?: &arg_identity_extra), "memberOf"));
 
                                 r = sd_json_variant_strv(mo, &list);
                                 if (r < 0)

--- a/test/units/TEST-46-HOMED.sh
+++ b/test/units/TEST-46-HOMED.sh
@@ -82,6 +82,29 @@ inspect test-user
 SYSTEMD_LOG_LEVEL=debug PASSWORD=yPN4N0fYNKUkOq NEWPASSWORD=xEhErW0ndafV4s homectl passwd test-user
 inspect test-user
 
+# --member-of=
+systemd-sysusers --inline "g test-group1" "g test-group2"
+# Single group
+PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of="test-group1"
+[[ "$(homectl inspect -j test-user | jq -c .memberOf)" == '["test-group1"]' ]]
+# Multiple groups
+PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of="test-group1,test-group2"
+[[ "$(homectl inspect -j test-user | jq -c .memberOf)" == '["test-group1","test-group2"]' ]]
+# Empty argument
+PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of=
+[[ "$(homectl inspect -j test-user | jq -c .memberOf)" == 'null' ]]
+# Argument shenanigans
+#   - only separators
+(! PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of=",,,,,,,,,,,,,,,,,,")
+#   - invalid group
+(! PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of="test-group1,inv@lid.group?")
+#   - separators & valid groups
+PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of=",,,,,test-group1,,,,,,,,,,,,,,test-group2,"
+[[ "$(homectl inspect -j test-user | jq -c .memberOf)" == '["test-group1","test-group2"]' ]]
+#   - duplicate groups
+PASSWORD=xEhErW0ndafV4s homectl update test-user --member-of="test-group2,test-group1,test-group1,test-group2"
+[[ "$(homectl inspect -j test-user | jq -c .memberOf)" == '["test-group1","test-group2"]' ]]
+
 homectl deactivate test-user
 inspect test-user
 


### PR DESCRIPTION
Commit 0e1ede4b4b6d1ce6b5b6cda5f803e4f1b5aa4a03 introduced a bug where we'd always fetch the "original" (empty) list of groups when processing a comma-separated list of groups from the --member-of= option, so only the last group from the list would get applied. This bug was then later (in 316e9887f2a48bd1c4efa3e31b4bfbaeb22de3a3) refactored into a separate function.

Follow-up for 0e1ede4b4b6d1ce6b5b6cda5f803e4f1b5aa4a03. Fixes: #41286

(cherry picked from commit f912de93125bcf0b6c59770503424bcafc683e78)

Resolves: RHEL-180924

<!-- issue-commentator = {"comment-id":"4843988313"} -->